### PR TITLE
fix: fix node/fees query string

### DIFF
--- a/src/API/Node.php
+++ b/src/API/Node.php
@@ -59,6 +59,6 @@ class Node extends AbstractAPI
      */
     public function fees(int $days = null): array
     {
-        return $this->get('node/fees', ['query' => ['days' => $days]]);
+        return $this->get('node/fees', ['days' => $days]);
     }
 }


### PR DESCRIPTION
A summary of what changes this PR introduces and why they were made.

## What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No

## Does this PR release a new version?

- [x] No

Prior to this change:
```
>>> $c->fees(30)
GuzzleHttp/Exception/ClientException with message 'Client error: `GET https://api.ark.io/api/node/fees?query%5Bdays%5D=20` resulted in a `422 Unprocessable Entity` response:
{"statusCode":422,"error":"Unprocessable Entity","message":"/"query[days]/" is not allowed"}
```
I'm sending this PR to `master` because `develop` is way behind.
