### PR TITLE
chore: update guzzlehttp/guzzle & illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     }],
     "require": {
         "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.5",
-        "illuminate/support": "^6.0|^7.0"
+        "guzzlehttp/guzzle": "^6.5|^7.0",
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
## Summary

### What changes are being made? 
* Updated [illuminate/support](https://packagist.org/packages/illuminate/support) to `^8.0` (8.3 currently)
* Updated [guzzlehttp/guzzle](https://packagist.org/packages/guzzlehttp/guzzle) to `^7.0` (7.0 currently)

### Why are these changes necessary?
I would like to use this package with Laravel 8.X

```sh
$ composer require arkecosystem/client
Using version ^1.2 for arkecosystem/client
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Can only install one of: guzzlehttp/guzzle[7.0.1, 6.5.x-dev].
    - Can only install one of: guzzlehttp/guzzle[6.5.x-dev, 7.0.1].
    - Can only install one of: guzzlehttp/guzzle[6.5.x-dev, 7.0.1].
    - arkecosystem/client 1.2.0 requires guzzlehttp/guzzle ^6.5 -> satisfiable by guzzlehttp/guzzle[6.5.x-dev].
    - Installation request for arkecosystem/client ^1.2 -> satisfiable by arkecosystem/client[1.2.0].
    - Installation request for guzzlehttp/guzzle (locked at 7.0.1, required as ^7.0.1) -> satisfiable by guzzlehttp/guzzle[7.0.1].
```

### How were these changes implemented?
Just updated the `composer.json`, `composer install`'ed and ran the tests with `./vendor/bin/phpunit`

## Checklist

- [x] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

Gone through the [Guzzle Upgrade Guide](https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#60-to-70) and couldn't find any problems.

## Left to do
- [ ] Changelog
- [ ] Create release
