### PR TITLE
fix: return types, dependencies and documentation link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 phpunit.xml
 vendor
 clover.xml
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 1.3.1 - 2020-09-16
+
+### Fixed:
+
+- Fix return types
+
+## 1.3.0 - 2020-09-16
+
+### Changed:
+
+- Update requirements to allow Laravel 8 and Guzzle 7
+
+## 1.2.0 - 2020-04-28
+
+### Added:
+
+- Methods for first and last block
+- Support for laravel 7
+
 ## 1.1.0 - 2020-02-11
 
 ### Added
@@ -68,4 +87,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add explicit class name casting with ucfirst
 
 ## 0.1.0 - 2018-06-28
+
 - Initial Release

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Documentation
 
-You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://docs.ark.io/sdk/clients/usage.html).
+You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://sdk.ark.dev/php/client).
 
 ## Security
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     }],
     "require": {
         "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.5",
-        "illuminate/support": "^6.0|^7.0"
+        "guzzlehttp/guzzle": "^6.5|^7.0",
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/src/API/AbstractAPI.php
+++ b/src/API/AbstractAPI.php
@@ -48,7 +48,7 @@ abstract class AbstractAPI
      * @param string $path
      * @param array  $query
      *
-     * @return array|string
+     * @return array|null|bool
      */
     protected function get(string $path, array $query = [])
     {
@@ -63,7 +63,7 @@ abstract class AbstractAPI
      * @param string $path
      * @param array  $parameters
      *
-     * @return array|string
+     * @return array|null|bool
      */
     protected function post(string $path, array $parameters = [])
     {

--- a/src/API/Blocks.php
+++ b/src/API/Blocks.php
@@ -27,7 +27,7 @@ class Blocks extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('blocks', $query);
     }
@@ -39,7 +39,7 @@ class Blocks extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $id): array
+    public function show(string $id): ?array
     {
         return $this->get("blocks/{$id}");
     }
@@ -49,7 +49,7 @@ class Blocks extends AbstractAPI
      *
      * @return array
      */
-    public function first(): array
+    public function first(): ?array
     {
         return $this->get('blocks/first');
     }
@@ -59,7 +59,7 @@ class Blocks extends AbstractAPI
      *
      * @return array
      */
-    public function last(): array
+    public function last(): ?array
     {
         return $this->get('blocks/last');
     }
@@ -72,7 +72,7 @@ class Blocks extends AbstractAPI
      *
      * @return array
      */
-    public function transactions(string $id, array $query = []): array
+    public function transactions(string $id, array $query = []): ?array
     {
         return $this->get("blocks/{$id}/transactions", $query);
     }
@@ -84,7 +84,7 @@ class Blocks extends AbstractAPI
      *
      * @return array
      */
-    public function search(array $parameters): array
+    public function search(array $parameters): ?array
     {
         return $this->post('blocks/search', $parameters);
     }

--- a/src/API/Bridgechains.php
+++ b/src/API/Bridgechains.php
@@ -27,7 +27,7 @@ class Bridgechains extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('bridgechains', $query);
     }
@@ -39,7 +39,7 @@ class Bridgechains extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $id): array
+    public function show(string $id): ?array
     {
         return $this->get("bridgechain/{$id}");
     }
@@ -51,7 +51,7 @@ class Bridgechains extends AbstractAPI
      *
      * @return array
      */
-    public function search(array $parameters): array
+    public function search(array $parameters): ?array
     {
         return $this->post('bridgechain/search', $parameters);
     }

--- a/src/API/Businesses.php
+++ b/src/API/Businesses.php
@@ -27,7 +27,7 @@ class Businesses extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('businesses', $query);
     }
@@ -39,7 +39,7 @@ class Businesses extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $id): array
+    public function show(string $id): ?array
     {
         return $this->get("businesses/{$id}");
     }
@@ -52,7 +52,7 @@ class Businesses extends AbstractAPI
      *
      * @return array
      */
-    public function bridgechains(string $id, array $query = []): array
+    public function bridgechains(string $id, array $query = []): ?array
     {
         return $this->get("businesses/{$id}/bridgechains", $query);
     }
@@ -64,7 +64,7 @@ class Businesses extends AbstractAPI
      *
      * @return array
      */
-    public function search(array $parameters): array
+    public function search(array $parameters): ?array
     {
         return $this->post('businesses/search', $parameters);
     }

--- a/src/API/Delegates.php
+++ b/src/API/Delegates.php
@@ -27,7 +27,7 @@ class Delegates extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('delegates', $query);
     }
@@ -39,7 +39,7 @@ class Delegates extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $id): array
+    public function show(string $id): ?array
     {
         return $this->get("delegates/{$id}");
     }
@@ -52,7 +52,7 @@ class Delegates extends AbstractAPI
      *
      * @return array
      */
-    public function blocks(string $id, array $query = []): array
+    public function blocks(string $id, array $query = []): ?array
     {
         return $this->get("delegates/{$id}/blocks", $query);
     }
@@ -65,7 +65,7 @@ class Delegates extends AbstractAPI
      *
      * @return array
      */
-    public function voters(string $id, array $query = []): array
+    public function voters(string $id, array $query = []): ?array
     {
         return $this->get("delegates/{$id}/voters", $query);
     }

--- a/src/API/Locks.php
+++ b/src/API/Locks.php
@@ -27,7 +27,7 @@ class Locks extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('locks', $query);
     }
@@ -39,7 +39,7 @@ class Locks extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $id): array
+    public function show(string $id): ?array
     {
         return $this->get("locks/{$id}");
     }
@@ -51,7 +51,7 @@ class Locks extends AbstractAPI
      *
      * @return array
      */
-    public function search(array $parameters): array
+    public function search(array $parameters): ?array
     {
         return $this->post('locks/search', $parameters);
     }
@@ -63,7 +63,7 @@ class Locks extends AbstractAPI
      *
      * @return array
      */
-    public function unlocked(array $parameters): array
+    public function unlocked(array $parameters): ?array
     {
         return $this->post('locks/unlocked', $parameters);
     }

--- a/src/API/Node.php
+++ b/src/API/Node.php
@@ -25,7 +25,7 @@ class Node extends AbstractAPI
      *
      * @return array
      */
-    public function status(): array
+    public function status(): ?array
     {
         return $this->get('node/status');
     }
@@ -35,7 +35,7 @@ class Node extends AbstractAPI
      *
      * @return array
      */
-    public function syncing(): array
+    public function syncing(): ?array
     {
         return $this->get('node/syncing');
     }
@@ -45,7 +45,7 @@ class Node extends AbstractAPI
      *
      * @return array
      */
-    public function configuration(): array
+    public function configuration(): ?array
     {
         return $this->get('node/configuration');
     }
@@ -55,7 +55,7 @@ class Node extends AbstractAPI
      *
      * @return array
      */
-    public function crypto(): array
+    public function crypto(): ?array
     {
         return $this->get('node/configuration/crypto');
     }
@@ -67,7 +67,7 @@ class Node extends AbstractAPI
      *
      * @return array
      */
-    public function fees(int $days = null): array
+    public function fees(int $days = null): ?array
     {
         return $this->get('node/fees', ['days' => $days]);
     }

--- a/src/API/Peers.php
+++ b/src/API/Peers.php
@@ -27,7 +27,7 @@ class Peers extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('peers', $query);
     }
@@ -39,7 +39,7 @@ class Peers extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $ip): array
+    public function show(string $ip): ?array
     {
         return $this->get("peers/{$ip}");
     }

--- a/src/API/Rounds.php
+++ b/src/API/Rounds.php
@@ -27,7 +27,7 @@ class Rounds extends AbstractAPI
      *
      * @return array
      */
-    public function delegates(int $round_id): array
+    public function delegates(int $round_id): ?array
     {
         return $this->get("rounds/{$round_id}/delegates");
     }

--- a/src/API/Transactions.php
+++ b/src/API/Transactions.php
@@ -27,7 +27,7 @@ class Transactions extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('transactions', $query);
     }
@@ -39,7 +39,7 @@ class Transactions extends AbstractAPI
      *
      * @return array
      */
-    public function create(array $transactions): array
+    public function create(array $transactions): ?array
     {
         return $this->post('transactions', compact('transactions'));
     }
@@ -51,7 +51,7 @@ class Transactions extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $id): array
+    public function show(string $id): ?array
     {
         return $this->get("transactions/{$id}");
     }
@@ -61,7 +61,7 @@ class Transactions extends AbstractAPI
      *
      * @return array
      */
-    public function allUnconfirmed(): array
+    public function allUnconfirmed(): ?array
     {
         return $this->get('transactions/unconfirmed');
     }
@@ -73,7 +73,7 @@ class Transactions extends AbstractAPI
      *
      * @return array
      */
-    public function showUnconfirmed(string $id): array
+    public function showUnconfirmed(string $id): ?array
     {
         return $this->get("transactions/unconfirmed/{$id}");
     }
@@ -85,7 +85,7 @@ class Transactions extends AbstractAPI
      *
      * @return array
      */
-    public function search(array $parameters): array
+    public function search(array $parameters): ?array
     {
         return $this->post('transactions/search', $parameters);
     }
@@ -95,7 +95,7 @@ class Transactions extends AbstractAPI
      *
      * @return array
      */
-    public function types(): array
+    public function types(): ?array
     {
         return $this->get('transactions/types');
     }
@@ -105,7 +105,7 @@ class Transactions extends AbstractAPI
      *
      * @return array
      */
-    public function fees(): array
+    public function fees(): ?array
     {
         return $this->get('transactions/fees');
     }

--- a/src/API/Votes.php
+++ b/src/API/Votes.php
@@ -27,7 +27,7 @@ class Votes extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('votes', $query);
     }
@@ -39,7 +39,7 @@ class Votes extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $id): array
+    public function show(string $id): ?array
     {
         return $this->get("votes/{$id}");
     }

--- a/src/API/Wallets.php
+++ b/src/API/Wallets.php
@@ -27,7 +27,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function all(array $query = []): array
+    public function all(array $query = []): ?array
     {
         return $this->get('wallets', $query);
     }
@@ -39,7 +39,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function show(string $id): array
+    public function show(string $id): ?array
     {
         return $this->get("wallets/{$id}");
     }
@@ -52,7 +52,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function locks(string $id, array $query = []): array
+    public function locks(string $id, array $query = []): ?array
     {
         return $this->get("wallets/{$id}/locks", $query);
     }
@@ -65,7 +65,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function transactions(string $id, array $query = []): array
+    public function transactions(string $id, array $query = []): ?array
     {
         return $this->get("wallets/{$id}/transactions", $query);
     }
@@ -78,7 +78,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function sentTransactions(string $id, array $query = []): array
+    public function sentTransactions(string $id, array $query = []): ?array
     {
         return $this->get("wallets/{$id}/transactions/sent", $query);
     }
@@ -91,7 +91,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function receivedTransactions(string $id, array $query = []): array
+    public function receivedTransactions(string $id, array $query = []): ?array
     {
         return $this->get("wallets/{$id}/transactions/received", $query);
     }
@@ -104,7 +104,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function votes(string $id, array $query = []): array
+    public function votes(string $id, array $query = []): ?array
     {
         return $this->get("wallets/{$id}/votes", $query);
     }
@@ -116,7 +116,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function search(array $parameters): array
+    public function search(array $parameters): ?array
     {
         return $this->post('wallets/search', $parameters);
     }
@@ -126,7 +126,7 @@ class Wallets extends AbstractAPI
      *
      * @return array
      */
-    public function top(): array
+    public function top(): ?array
     {
         return $this->get('wallets/top');
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -17,6 +17,7 @@ use RuntimeException;
 use GuzzleHttp\Client;
 use BadMethodCallException;
 use GuzzleHttp\HandlerStack;
+use Illuminate\Support\Str;
 
 /**
  * This is the connection class.
@@ -41,7 +42,7 @@ class Connection
     public function __construct(array $config, HandlerStack $handler = null)
     {
         $options = [
-            'base_uri' => $config['host'],
+            'base_uri' => Str::finish($config['host'], '/'),
             'headers' => [
                 'Content-Type' => 'application/json',
             ],


### PR DESCRIPTION
## Summary

- Link to documentation redirected to the main documentation site, I changed it so it opens the PHP-Client documentation directly.

## Checklist

- [x] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged