### PR TITLE
chore: update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/support": "^11.10"
+        "illuminate/support": "^11.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.58",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/support": "^11.0"
+        "illuminate/support": "^13.5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.58",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/86e0tw4ff

When upgrading illuminate/support in this package, then re-adding to faucet, it only updated arkecosystem/client meaning everything else was already at `illuminate/support:^13.5`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
